### PR TITLE
gitlab-ci: run strip-nondeterminism to generate exact binaries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ before_script:
         android-sdk
         android-sdk-platform-23
         libgradle-android-plugin-java
+        strip-nondeterminism
 
 build_on_debian:
   stage: test
@@ -30,6 +31,7 @@ build_on_debian:
     - gh-pages
   script:
     - gradle jarRelease
+    - for f in build/libs/*.*; do strip-nondeterminism $f; done
     - for f in build/libs/*.*; do sha256sum $f; done
   artifacts:
     name: "${CI_PROJECT_PATH}_${CI_COMMIT_REF_NAME}_${CI_COMMIT_SHA}_${CI_JOB_NAME}"


### PR DESCRIPTION
This will fix things like timestamps and sort order in the ZIP header.